### PR TITLE
Adds retries to docker-py role, updates Ansible to 2.2.0.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ RUN apt-get update && apt-get install -y \
 COPY . /opt/loom/
 RUN virtualenv /opt/loom \
     && . /opt/loom/bin/activate \
-    && pip install -e /opt/loom \
-    && pip install git+git://github.com/ansible/ansible.git@devel
+    && pip install -e /opt/loom --process-dependency-links
 
 # Add Loom to the path.
 ENV PATH /opt/loom/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update && apt-get install -y \
 COPY . /opt/loom/
 RUN virtualenv /opt/loom \
     && . /opt/loom/bin/activate \
-    && pip install -e /opt/loom --process-dependency-links
+    && pip install git+git://github.com/ansible/ansible.git@v2.2.0.0-0.1.rc1 \
+    && pip install -e /opt/loom 
 
 # Add Loom to the path.
 ENV PATH /opt/loom/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update && apt-get install -y \
 COPY . /opt/loom/
 RUN virtualenv /opt/loom \
     && . /opt/loom/bin/activate \
-    && pip install -e /opt/loom 
+    && pip install -e /opt/loom \
+    && pip install git+git://github.com/ansible/ansible.git@devel
 
 # Add Loom to the path.
 ENV PATH /opt/loom/bin:$PATH

--- a/loomengine/playbooks/roles/docker-py/tasks/main.yml
+++ b/loomengine/playbooks/roles/docker-py/tasks/main.yml
@@ -5,5 +5,11 @@
       baseurl: http://download.fedoraproject.org/pub/epel/$releasever/$basearch/
   - name: Install pip, which is needed to install docker-py.
     yum: name=python-pip disable_gpg_check=yes update_cache=yes
+    register: pipinstallresult
+    retries: 10
+    until: pipinstallresult['rc'] == 0
   - name: Install docker-py, which is required by Ansible to use Docker modules.
     pip: name=docker-py version=1.9.0
+    register: dockerpyinstallresult
+    retries: 10
+    until: dockerpyinstallresult['state'] == 'present'

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
+                        'ansible==2.2.0.0',
                         'apache-libcloud==1.2.1',
                         'Django>=1.8,<1.9',
                         'django-cors-headers>=1.1.0',
@@ -119,6 +120,7 @@ setup(
                         'setuptools-git>=1.1',
                         'twine',
     ],
+    dependency_links=['https://github.com/ansible/ansible/archive/v2.2.0.0-0.1.rc1.tar.gz#egg=ansible-2.2.0.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-                        'ansible==2.1.1.0',
+                        'ansible==2.2',
                         'apache-libcloud==1.2.1',
                         'Django>=1.8,<1.9',
                         'django-cors-headers>=1.1.0',
@@ -120,6 +120,9 @@ setup(
                         'setuptools-git>=1.1',
                         'twine',
     ],
+
+    #dependency_links=['git+git://github.com/ansible/ansible.git@devel'],
+    dependency_links=['https://github.com//ansible/ansible/tarball/devel#egg=ansible-2.2'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-                        'ansible==2.2',
                         'apache-libcloud==1.2.1',
                         'Django>=1.8,<1.9',
                         'django-cors-headers>=1.1.0',
@@ -120,9 +119,6 @@ setup(
                         'setuptools-git>=1.1',
                         'twine',
     ],
-
-    #dependency_links=['git+git://github.com/ansible/ansible.git@devel'],
-    dependency_links=['https://github.com//ansible/ansible/tarball/devel#egg=ansible-2.2'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,6 @@ setup(
                         'setuptools-git>=1.1',
                         'twine',
     ],
-    dependency_links=['https://github.com/ansible/ansible/archive/v2.2.0.0-0.1.rc1.tar.gz#egg=ansible-2.2.0.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Since Ansible 2.2.0.0 is not in PyPI yet, clients will need to install it before Loom like this:

pip install git+git://github.com/ansible/ansible.git@v2.2.0.0-0.1.rc1

I've added this to the Dockerfile, so servers and workers should be fine.