### PR TITLE
Delete on termination

### DIFF
--- a/loomengine/client/playbooks/gcloud_run_task.yml
+++ b/loomengine/client/playbooks/gcloud_run_task.yml
@@ -58,12 +58,6 @@
       - scratch_disk_name is defined
       - scratch_disk_type is defined
       - scratch_disk_size_gb is defined
-    - name: Set scratch disk to be deleted with the instance.
-      shell: gcloud compute instances set-disk-auto-delete {{instance_name}} --auto-delete --disk {{scratch_disk_name}} --zone {{zone}}
-      when:
-      - scratch_disk_name is defined
-      - scratch_disk_type is defined
-      - scratch_disk_size_gb is defined
 
 - name: Format and mount the scratch disk on the Loom worker.
   hosts: new_instances

--- a/loomengine/client/playbooks/gcloud_run_task.yml
+++ b/loomengine/client/playbooks/gcloud_run_task.yml
@@ -53,11 +53,15 @@
   - vars/gcloud_worker.yml
   tasks:
     - name: Create a scratch disk and attach it to the instance.
-      gce_pd: instance_name={{instance_name}} name={{scratch_disk_name}} disk_type={{scratch_disk_type}} size_gb={{scratch_disk_size_gb}} zone={{zone}} mode=READ_WRITE service_account_email={{gce_email}} credentials_file={{gce_credential}} project_id={{gce_project}}
+      gce_pd: instance_name={{instance_name}} name={{scratch_disk_name}} disk_type={{scratch_disk_type}} size_gb={{scratch_disk_size_gb}} zone={{zone}} mode=READ_WRITE service_account_email={{gce_email}} credentials_file={{gce_credential}} project_id={{gce_project}} delete_on_termination=yes
       when:
       - scratch_disk_name is defined
       - scratch_disk_type is defined
       - scratch_disk_size_gb is defined
+      register: gce_pd
+      until: gce_pd.state == "present"
+      retries: 5
+      delay: 5
 
 - name: Format and mount the scratch disk on the Loom worker.
   hosts: new_instances

--- a/loomengine/client/playbooks/tasks/gcloud_create_instance.yml
+++ b/loomengine/client/playbooks/tasks/gcloud_create_instance.yml
@@ -8,7 +8,6 @@
   - name: Boot up a new instance using the just-created boot disk.
     gce:
       name: "{{instance_name}}"
-      delete_on_termination: yes
       disks: "{{instance_name}}"
       zone: "{{zone}}"
       machine_type: "{{instance_type if instance_type|trim else omit}}"
@@ -24,6 +23,7 @@
     until: gce_result.state == "present"
     retries: 5
     delay: 5
+
   - name: Add host IP to new_instances for downstream plays. Use internal or external IP depending on setting.
     add_host: hostname={{ (use_internal_ip) | ternary(item.private_ip, item.public_ip) }} groupname=new_instances
     with_items: '{{ gce_result.instance_data }}'

--- a/loomengine/client/playbooks/tasks/gcloud_create_instance.yml
+++ b/loomengine/client/playbooks/tasks/gcloud_create_instance.yml
@@ -8,6 +8,7 @@
   - name: Boot up a new instance using the just-created boot disk.
     gce:
       name: "{{instance_name}}"
+      delete_on_termination: yes
       disks: "{{instance_name}}"
       zone: "{{zone}}"
       machine_type: "{{instance_type if instance_type|trim else omit}}"


### PR DESCRIPTION
Ansible 2.3 gce_pd module adds a "delete_on_termination" option. This PR removes an old "shell" command that was setting this property for worker scratch disks, and uses the delete_on_termination flag instead. It also adds retries to the step.