### PR TITLE
always check "is defined" before using key in ansible "until"

### DIFF
--- a/loomengine/client/playbooks/gcloud_run_task.yml
+++ b/loomengine/client/playbooks/gcloud_run_task.yml
@@ -59,7 +59,7 @@
       - scratch_disk_type is defined
       - scratch_disk_size_gb is defined
       register: gce_pd
-      until: gce_pd.state == "present"
+      until: gce_pd['state'] is defined and gce_pd['state'] == "present"
       retries: 5
       delay: 5
 

--- a/loomengine/client/playbooks/roles/docker-py/tasks/main.yml
+++ b/loomengine/client/playbooks/roles/docker-py/tasks/main.yml
@@ -23,10 +23,10 @@
     pip: name=requests version=2.12.1
     register: requestsinstallresult
     retries: 10
-    until: requestsinstallresult['state'] == 'present'
+    until: requestsinstallresult['state'] is defined and requestsinstallresult['state'] == 'present'
 
   - name: Install docker-py, which is required by Ansible to use Docker modules.
     pip: name=docker-py version=1.10.6
     register: dockerpyinstallresult
     retries: 10
-    until: dockerpyinstallresult['state'] == 'present'
+    until: dockerpyinstallresult['state'] is defined and dockerpyinstallresult['state'] == 'present'

--- a/loomengine/client/playbooks/tasks/gcloud_create_instance.yml
+++ b/loomengine/client/playbooks/tasks/gcloud_create_instance.yml
@@ -1,7 +1,7 @@
   - name: Create a boot disk with the same name as the instance.
     gce_pd: name={{instance_name}} image={{instance_image}} disk_type={{boot_disk_type}} size_gb={{boot_disk_size_gb}} zone={{zone}} mode=READ_WRITE service_account_email={{gce_email}} credentials_file={{gce_credential}} project_id={{gce_project}}
     register: pd_result
-    until: pd_result.state == "present"
+    until: pd_result['state'] is defined and pd_result['state'] == "present"
     retries: 5
     delay: 5
 
@@ -20,7 +20,7 @@
       tags: "{{tags if tags|trim else omit}}"
       external_ip: "{{external_ip if external_ip|trim else omit}}"
     register: gce_result
-    until: gce_result.state == "present"
+    until: gce_result['state'] is defined and gce_result['state'] == "present"
     retries: 5
     delay: 5
 

--- a/loomengine/client/playbooks/tasks/wait_for_server_to_start.yml
+++ b/loomengine/client/playbooks/tasks/wait_for_server_to_start.yml
@@ -9,6 +9,6 @@
 - name: Wait for Loom server to start. (retry messages are normal)
   uri: "url={{server_url}}/api/status/ validate_certs=False"
   register: response
-  until: response.status == 200
+  until: response['status'] is defined and response['status'] == 200
   retries: 30
   delay: 10


### PR DESCRIPTION
Use this syntax throughout playbooks:

```
until: x.y is defined and x.y == 'target_value'
```

Failing on x.y because y is undefined was failing to retry and also masking the true error in logs.