### PR TITLE
add expanded /inputs and /outputs detail routes on runs

### DIFF
--- a/loomengine/master/api/test/serializers/test_runs.py
+++ b/loomengine/master/api/test/serializers/test_runs.py
@@ -53,7 +53,6 @@ class TestRunSerializer(TransactionTestCase):
         m = Template.objects.get(id=m.id)
         run = Run.create_from_template(m)
 
-        import pdb; pdb.set_trace()
         self.assertEqual(
             m.uuid,
             RunSerializer(run, context=get_mock_context()).data[

--- a/loomengine/master/api/test/serializers/test_runs.py
+++ b/loomengine/master/api/test/serializers/test_runs.py
@@ -53,6 +53,7 @@ class TestRunSerializer(TransactionTestCase):
         m = Template.objects.get(id=m.id)
         run = Run.create_from_template(m)
 
+        import pdb; pdb.set_trace()
         self.assertEqual(
             m.uuid,
             RunSerializer(run, context=get_mock_context()).data[

--- a/loomengine/master/api/views.py
+++ b/loomengine/master/api/views.py
@@ -568,8 +568,40 @@ class RunViewSet(ExpandableViewSet):
                            .prefetch_related('steprun__timepoints')
         return queryset.order_by('-datetime_created')
 
+    @detail_route(methods=['get'], url_path='inputs')
+    def inputs(self, request, uuid=None):
+        try:
+            run = models.Run.objects.get(uuid=uuid)
+        except ObjectDoesNotExist:
+            return JsonResponse({"message": "Not Found"}, status=404)
+        if run.type == 'step':
+            RunInputSerializer = serializers.StepRunInputSerializer
+        else:
+            RunInputSerializer = serializers.WorkflowRunInputSerializer
+        run_input_serializer = RunInputSerializer(run.inputs.all(),
+                                          many=True,
+                                          context={'request': request,
+                                                   'expand': True})
+        return JsonResponse(run_input_serializer.data, status=200, safe=False)
 
-class StepRunViewSet(ExpandableViewSet):
+    @detail_route(methods=['get'], url_path='outputs')
+    def outputs(self, request, uuid=None):
+        try:
+            run = models.Run.objects.get(uuid=uuid)
+        except ObjectDoesNotExist:
+            return JsonResponse({"message": "Not Found"}, status=404)
+        if run.type == 'step':
+            RunOutputSerializer = serializers.StepRunOutputSerializer
+        else:
+            RunOutputSerializer = serializers.WorkflowRunOutputSerializer
+        run_output_serializer = RunOutputSerializer(run.outputs.all(),
+                                          many=True,
+                                          context={'request': request,
+                                                   'expand': True})
+        return JsonResponse(run_output_serializer.data, status=200, safe=False)
+
+
+class StepRunViewSet(RunViewSet):
     """
     Runs of type 'step', which contain a command
     and runtime environment.
@@ -601,7 +633,7 @@ class StepRunViewSet(ExpandableViewSet):
         return queryset.order_by('-datetime_created')
 
 
-class WorkflowRunViewSet(ExpandableViewSet):
+class WorkflowRunViewSet(RunViewSet):
     """
     Runs of type 'workflow', which act as containers
     for other Runs. 


### PR DESCRIPTION
Added these two endponts:

GET /api/runs/{uuid}/inputs/
GET /api/runs/{uuid}/outputs/

These are meant to make it easier to get URLs for all input/output files for a run. For performance reasons, inputs and outputs in the main run view are not expanded, so it takes several GET requests to navigate to the data tree, and then to the file resource which lists the file URL. But in these new views, all of that data is included and available with a single GET request.