### PR TITLE
use force_rerun settings in bulk_create_tasks

### DIFF
--- a/server/loomengine_server/api/models/runs.py
+++ b/server/loomengine_server/api/models/runs.py
@@ -244,7 +244,8 @@ class Run(BaseModel):
                 unsaved_task_outputs.extend(task_outputs)
                 unsaved_data_nodes.update(data_nodes)
         Task.bulk_create_tasks(unsaved_tasks, unsaved_task_inputs,
-                               unsaved_task_outputs, unsaved_data_nodes)
+                               unsaved_task_outputs, unsaved_data_nodes,
+                               self.force_rerun)
 
     def push_all_outputs(self):
         for run in self._get_downstream_runs():

--- a/server/loomengine_server/api/models/tasks.py
+++ b/server/loomengine_server/api/models/tasks.py
@@ -240,7 +240,7 @@ class Task(BaseModel):
 
     @classmethod
     def bulk_create_tasks(cls, unsaved_tasks, unsaved_task_inputs,
-                       unsaved_task_outputs, unsaved_data_nodes):
+                          unsaved_task_outputs, unsaved_data_nodes, force_rerun):
         if get_setting('TEST_NO_CREATE_TASK'):
             return
         all_data_nodes = DataNode.save_list_with_children(unsaved_data_nodes.values())
@@ -264,7 +264,7 @@ class Task(BaseModel):
             task.run.set_running_status()
 
         for task in tasks:
-            task.execute()
+            task.execute(force_rerun=force_rerun)
         return tasks
 
     @classmethod


### PR DESCRIPTION
force_rerun option was being ignored in most cases. This change restores it. Fixes #576 